### PR TITLE
All reminders display at root directory

### DIFF
--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  title: DS.attr('string'),
+  date: DS.attr('string'),
+  notes: DS.attr('string'),
+});

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,6 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('/');
   this.route('reminders');
 });
 

--- a/app/router.js
+++ b/app/router.js
@@ -7,6 +7,8 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('/');
+  this.route('reminders');
 });
 
 export default Router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel(){
+    this.replaceWith('/reminders')
+  }
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel(){
-    this.replaceWith('/reminders')
+  // beforeModel(){
+  //   this.replaceWith('/reminders')
+  // }
+  model (){
+    return this.get('store').findAll('reminder')
   }
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,9 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  // beforeModel(){
-  //   this.replaceWith('/reminders')
-  // }
   model (){
     return this.get('store').findAll('reminder')
   }

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 
-
 export default Ember.Route.extend({
   model(){
   }

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -1,9 +1,7 @@
 import Ember from 'ember';
 
-const reminder = [1,2,3,4,5]
 
 export default Ember.Route.extend({
   model(){
-    return reminder
   }
 });

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+const reminder = [1,2,3,4,5]
+
+export default Ember.Route.extend({
+  model(){
+    return reminder
+  }
+});

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,3 +1,9 @@
 <div>hello</div>
-
+{{#each model as |reminder|}}
+  <li class="spec-reminder-item">
+    {{reminder.title}}
+    <div>{{reminder.date}}</div>
+    <div>{{reminder.notes}}</div>
+  </li>
+{{/each}}
 {{outlet}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,0 +1,3 @@
+<div>hello</div>
+
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,0 +1,7 @@
+<div>reminders</div>
+{{#each model as |reminder|}}
+  <li class="spec-reminder-item">
+    {{reminder}}
+  </li>
+{{/each}}
+{{outlet}}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "dependencies": {
-    "ember": "~2.8.0",
+    "ember": "~2.11.0",
     "ember-cli-shims": "0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.8.0",
+    "ember-data": "^2.11.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -13,12 +13,12 @@ test('viewing the homepage', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(currentURL(), '/');
-    assert.equal(Ember.$('.spec-reminder-item').length, 5);
+    assert.equal(currentURL(), '/reminders', 'visting homepage reroutes to /reminders');
+    assert.equal(Ember.$('.spec-reminder-item').length, 5, 'renders 5 reminders with class .spec-reminder-item');
   });
 });
 
-test('clicking on an individual item', function(assert) {
+skip('clicking on an individual item', function(assert) {
   server.createList('reminder', 5);
 
   visit('/');

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -13,7 +13,7 @@ test('viewing the homepage', function(assert) {
   visit('/');
 
   andThen(function() {
-    assert.equal(currentURL(), '/reminders', 'visting homepage reroutes to /reminders');
+    assert.equal(currentURL(), '/', 'visting homepage');
     assert.equal(Ember.$('.spec-reminder-item').length, 5, 'renders 5 reminders with class .spec-reminder-item');
   });
 });

--- a/tests/unit/models/reminder-test.js
+++ b/tests/unit/models/reminder-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('reminder', 'Unit | Model | reminder', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:index', 'Unit | Route | index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/reminders-test.js
+++ b/tests/unit/routes/reminders-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:reminders', 'Unit | Route | reminders', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
## Purpose
closes #1
When the user visits the root of the application (e.g. the "/" URL), they should see a list of all of the reminders on the page. Each reminder should have a class of .spec-reminder-item. There is a failing test set up in tests/acceptance/reminder-list-test.js.

## Approach

We set up an index route. The reminder model returns an array of reminders, brought in from mirage. we use {{each} to map over the array of reminders and post them to the page as a list with each li having a class of .spec-reminder-item

### Learning

used the turing lessons on ember routing and the ember-groceries class to figure this out as well as the ember docs getting started guide. used that same lesson to figure out the basics of mirage, and some assistance from Big Mike Z to get it all hooked up. 

#### Blog Posts

### Open Questions and Pre-Merge TODOs
we have issue 2 set up and commented out. ignore that stuff plz. 

### Test coverage 

we just used the existing tests, and added descriptions so they show what they're doing semantically instead of just turing green and saying okay. 

### Merge Dependencies and Related Work

????????????????

### Follow-up tasks

- [Issue #2 ](https://github.com/turingschool-projects/1610-remember-6/issues/2)

### Screenshots
#### Before
<img width="759" alt="issue1-before" src="https://cloud.githubusercontent.com/assets/20474299/22760109/5819305c-ee12-11e6-8808-ac4d43b04309.png">

#### After
<img width="924" alt="issue1-after" src="https://cloud.githubusercontent.com/assets/20474299/22760169/854f156e-ee12-11e6-9883-987d3198cf64.png">

#### Tests
<img width="1023" alt="passing test" src="https://cloud.githubusercontent.com/assets/20474299/22760178/8e216fa2-ee12-11e6-9b8c-3b0c0776a82d.png">

