### PR TITLE
Individual reminders closes #3

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -8,9 +8,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
 
-  this.route('/');
   this.route('reminders', function(){
-    this.route('index', { path: '/' });
     this.route('reminder', { path: '/:id' });
   });
 });

--- a/app/router.js
+++ b/app/router.js
@@ -9,7 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
 
   this.route('reminders', function(){
-    this.route('reminder', { path: '/:id' });
+    this.route('reminder', { path: '/:reminder_id' });
   });
 });
 

--- a/app/router.js
+++ b/app/router.js
@@ -7,15 +7,12 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-<<<<<<< HEAD
-  this.route('reminders');
-=======
+
   this.route('/');
   this.route('reminders', function(){
     this.route('index', { path: '/' });
     this.route('reminder', { path: '/:id' });
   });
->>>>>>> d0186d1... create nested route for individual notes
 });
 
 export default Router;

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,15 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+<<<<<<< HEAD
   this.route('reminders');
+=======
+  this.route('/');
+  this.route('reminders', function(){
+    this.route('index', { path: '/' });
+    this.route('reminder', { path: '/:id' });
+  });
+>>>>>>> d0186d1... create nested route for individual notes
 });
 
 export default Router;

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model (){
-    return this.get('store').findAll('reminder');
+=    return this.get('store').findAll('reminder');
   }
 });

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model (){
-=    return this.get('store').findAll('reminder');
+    return this.get('store').findAll('reminder');
   }
 });

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model (){
-    return this.get('store').findAll('reminder')
+    return this.get('store').findAll('reminder');
   }
 });

--- a/app/routes/reminders/reminder.js
+++ b/app/routes/reminders/reminder.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model(params) {
+    return this.get('store').findRecord('reminder', params.id);
+  }
+});

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,0 +1,4 @@
+.active{
+  color: magenta;
+  font-weight: bold;
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,7 +1,7 @@
 <h1>Reminders</h1>
 {{#each model as |reminder|}}
-  <li class="spec-reminder-item">
-  {{#link-to "reminders.reminder" reminder}}
+  <li>
+  {{#link-to "reminders.reminder" reminder class="spec-reminder-item"}}
     {{reminder.title}}
   {{/link-to}}
   </li>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -2,8 +2,6 @@
 {{#each model as |reminder|}}
   <li class="spec-reminder-item">
     {{reminder.title}}
-    <div>{{reminder.date}}</div>
-    <div>{{reminder.notes}}</div>
   </li>
 {{/each}}
 {{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,7 +1,9 @@
-<h1>reminders</h1>
+<h1>Reminders</h1>
 {{#each model as |reminder|}}
   <li class="spec-reminder-item">
+  {{#link-to "reminders.reminder" reminder}}
     {{reminder.title}}
+  {{/link-to}}
   </li>
 {{/each}}
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,0 +1,5 @@
+<h1>Individual Reminder</h1>
+<div>{{model.title}}</div>
+<div>{{model.date}}</div>
+<div>{{model.notes}}</div>
+{{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,5 +1,4 @@
-<h1>Individual Reminder</h1>
-<div>{{model.title}}</div>
+<h1 class="spec-reminder-title">{{model.title}}</h1>
 <div>{{model.date}}</div>
 <div>{{model.notes}}</div>
 {{outlet}}

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -26,5 +26,6 @@ test('clicking on an individual item', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), '/reminders/1', 'clicking the first item links to url /1');
     assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim(), 'the individual title matches the first item in the reminders list');
+    assert.equal(Ember.$('.active').length, 1, 'one item has class active');
   });
 });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -1,6 +1,6 @@
 /* globals server */
 
-import { test, skip } from 'qunit';
+import { test } from 'qunit';
 import moduleForAcceptance from 'remember/tests/helpers/module-for-acceptance';
 
 import Ember from 'ember';
@@ -18,14 +18,13 @@ test('viewing the homepage', function(assert) {
   });
 });
 
-skip('clicking on an individual item', function(assert) {
+test('clicking on an individual item', function(assert) {
   server.createList('reminder', 5);
-
-  visit('/');
+  visit('/reminders');
   click('.spec-reminder-item:first');
 
   andThen(function() {
-    assert.equal(currentURL(), '/1');
-    assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim());
+    assert.equal(currentURL(), '/reminders/1', 'clicking the first item links to url /1');
+    assert.equal(Ember.$('.spec-reminder-item:first').text().trim(), Ember.$('.spec-reminder-title').text().trim(), 'the individual title matches the first item in the reminders list');
   });
 });


### PR DESCRIPTION
## Purpose

closes #3
When the user clicks on one of the reminders on the page, they are taken to an individual reminders route (ie: ‘/reminders/1’, if the id of the reminder is 1). The title of the reminder object should be displayed.

You’ll need a reminder route in addition to the reminders route.
It should be nested inside the reminders route.
The user should still see all of the reminders from your previous feature. The specific reminder they are looking at now should be rendered in the outlet of the reminders.hbs template.
There should be some CSS for the .active class.

## Approach

We created a nested route, then modified the router to link to the reminder:id when a reminder is selected. The index route displays reminder titles, and when a user clicks a title, the date and body of the reminder are displayed in the outlet. The class 'active' is automatically applied to a clicked link by ember (fancy af), so we just added a css magenta text-color to show that it is indeed active. 

### Test coverage 

The test you wrote has been modified to make a few additional asserts. we test for correct URL, correct, test, and for the class Active occuring. 


### Follow-up tasks

- [Issue #5 (Example)](https://github.com/turingschool-projects/1610-remember-6/issues/5)

### Screenshots

#### Before

![issue2-after](https://cloud.githubusercontent.com/assets/20474299/22857815/23e66854-f06a-11e6-839e-3dcb8c7523ab.png)

#### After

<img width="942" alt="issue-3-after" src="https://cloud.githubusercontent.com/assets/20474299/22857825/713f4a30-f06a-11e6-86f2-c4d22f13bfdc.png">

#### Tests

<img width="431" alt="issue-3-tests" src="https://cloud.githubusercontent.com/assets/20474299/22857828/7c092922-f06a-11e6-93bf-6a7500159c3d.png">

