### PR TITLE
Remove reminder closes #12

### DIFF
--- a/app/controllers/reminders.js
+++ b/app/controllers/reminders.js
@@ -4,7 +4,7 @@ export default Ember.Controller.extend({
   actions: {
     remove(id) {
       this.get('store').findRecord('reminder', id, {
-        backgroundReload: false }).then(function(post) {
+        backgroundReload: false }).then((post)=> {
         post.destroyRecord();
       }).then(()=>{
         this.transitionToRoute('reminders')

--- a/app/controllers/reminders.js
+++ b/app/controllers/reminders.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    remove(id) {
+      this.get('store').findRecord('reminder', id, {
+        backgroundReload: false }).then(function(post) {
+        post.destroyRecord();
+      }).then(()=>{
+        this.transitionToRoute('reminders')
+      })
+    }
+  }
+});

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -4,7 +4,7 @@ export default Ember.Controller.extend({
   actions: {
     remove(id) {
       this.get('store').findRecord('reminder', id, {
-        backgroundReload: false }).then(function(post) {
+        backgroundReload: false }).then((post)=> {
         post.destroyRecord();
       }).then(()=>{
         this.transitionToRoute('reminders')

--- a/app/controllers/reminders/reminder.js
+++ b/app/controllers/reminders/reminder.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  actions: {
+    remove(id) {
+      this.get('store').findRecord('reminder', id, {
+        backgroundReload: false }).then(function(post) {
+        post.destroyRecord();
+      }).then(()=>{
+        this.transitionToRoute('reminders')
+      })
+    }
+  }
+});

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -3,15 +3,18 @@
 {{#if model}}
   {{#each model as |reminder|}}
     <li>
-    {{#link-to "reminders.reminder" reminder class="spec-reminder-item"}}
-      {{reminder.title}}
-    {{/link-to}}
-    <button {{action 'remove' reminder.id}}>delete this reminder</button>
+      {{#link-to "reminders.reminder" reminder class="spec-reminder-item"}}
+        {{reminder.title}}
+      {{/link-to}}
+      <button class="spec-reminder-delete" {{action 'remove' reminder.id}}>
+        delete this reminder
+      </button>
     </li>
   {{/each}}
 {{else}}
-<div class="spec-prompt-message">enter a reminder</div>
+  <div class="spec-prompt-message">enter a reminder</div>
 {{/if}}
 
 {{link-to "New Reminder" "reminders.new"}}
+
 {{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -6,6 +6,7 @@
     {{#link-to "reminders.reminder" reminder class="spec-reminder-item"}}
       {{reminder.title}}
     {{/link-to}}
+    <button {{action 'remove' reminder.id}}>delete this reminder</button>
     </li>
   {{/each}}
 {{else}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,4 +1,5 @@
 <h1 class="spec-reminder-title">{{model.title}}</h1>
 <div>{{model.date}}</div>
 <div>{{model.notes}}</div>
+<button {{action 'remove' model.id}}>delete this reminder</button>
 {{outlet}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,5 +1,5 @@
 <h1 class="spec-reminder-title">{{model.title}}</h1>
 <div>{{model.date}}</div>
 <div>{{model.notes}}</div>
-<button {{action 'remove' model.id}}>delete this reminder</button>
+<button class="spec-delete-individual" {{action 'remove' model.id}}>delete this reminder</button>
 {{outlet}}

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,3 +1,3 @@
 export default function(server) {
-  // server.createList('reminder', 5);
+  server.createList('reminder', 5);
 }

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -40,3 +40,31 @@ test('Prompt user to enter new note when no notes are present', function(assert)
     assert.equal(find('.spec-prompt-message').text(), 'enter a reminder', 'should display a condescending message when no notes are present')
   })
 })
+
+test('Clicking delete removes from reminders..', function(assert) {
+  server.createList('reminder', 5);
+  visit('/reminders');
+  andThen(function() {
+    assert.equal(find('.spec-reminder-item').length, 5, 'there are 5 items present');
+    click('.spec-reminder-delete:first');
+  })
+  andThen(function() {
+    assert.equal(find('.spec-reminder-item').length, 4, 'now there are 4');
+  })
+})
+
+test('clicking delete from an individual reminder...', function(assert) {
+  server.createList('reminder', 5);
+  visit('/reminders');
+  click('.spec-reminder-item:first');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders/1', 'we are now on the nested URL');
+    click('.spec-delete-individual');
+  })
+
+  andThen(function() {
+    assert.equal(currentURL(),'/reminders', 'transition to reminders route')
+    assert.equal(find('.spec-reminder-item').length, 4, 'and the reminder has been deleted')
+  })
+});

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -67,4 +67,5 @@ test('clicking delete from an individual reminder...', function(assert) {
     assert.equal(currentURL(),'/reminders', 'transition to reminders route')
     assert.equal(find('.spec-reminder-item').length, 4, 'and the reminder has been deleted')
   })
+
 });

--- a/tests/unit/controllers/reminders-test.js
+++ b/tests/unit/controllers/reminders-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders', 'Unit | Controller | reminders', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/controllers/reminders/reminder-test.js
+++ b/tests/unit/controllers/reminders/reminder-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:reminders/reminder', 'Unit | Controller | reminders/reminder', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});


### PR DESCRIPTION
## Purpose

User can remove/delete a reminder.
Users should be able to remove a reminder from both the list of reminders or from an individual reminder’s page. If they do it from the individual reminder’s page, then the application should reroute them back to the /reminders route.
closes #12

## Approach

we added a controller with a delete action for the nested route 'reminders/reminder' and then copied that into a controller for the '/reminders' route

### Learning

Those people who write the ember docs sure know how to write helpful information.

### Test coverage 

We wrote tests to check that items were being deleted when the delete button is clicked and that we transition back to the route '/reminders' when on an individual reminder. 

### Next Issue
- Editing A Note #9
 (Example)](https://github.com/turingschool-projects/1610-remember-6/issues/9)

### Screenshots

#### Before
<img width="189" alt="issue-6after" src="https://cloud.githubusercontent.com/assets/20474299/22907545/f2bf8a32-f206-11e6-86f8-4ffd2cb53ebd.png">


#### After
<img width="458" alt="issue12-after" src="https://cloud.githubusercontent.com/assets/20474299/22907552/f84caf2a-f206-11e6-9fe4-fb8f2b6e1237.png">

#### Tests
<img width="1026" alt="issue12-tests" src="https://cloud.githubusercontent.com/assets/20474299/22907560/02c59a7a-f207-11e6-9589-9413bc874038.png">
