### PR TITLE
Rollback edits closes #10

### DIFF
--- a/app/controllers/reminders/reminder/edit.js
+++ b/app/controllers/reminders/reminder/edit.js
@@ -4,13 +4,19 @@ export default Ember.Controller.extend({
 
   actions: {
     updateNote(id) {
-      this.get('store').findRecord('reminder', id).then(function(reminder) {
+      this.get('store').findRecord('reminder', id).then((reminder)=> {
         reminder.set('title', reminder.get('title'))
         reminder.set('date', reminder.get('date'))
         reminder.set('notes', reminder.get('notes'))
         reminder.save();
       }).then(()=>{
         this.transitionToRoute('/reminders/' + this.model.id)
+      })
+    },
+
+    undoEdit(id) {
+      this.get('store').findRecord('reminder', id).then((reminder)=> {
+        reminder.rollbackAttributes();
       })
     }
   }

--- a/app/controllers/reminders/reminder/edit.js
+++ b/app/controllers/reminders/reminder/edit.js
@@ -1,22 +1,14 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  store: Ember.inject.service(),
-
-    title: '',
-    date: '',
-    notes: '',
 
   actions: {
     updateNote(id) {
-      const reminderProps = this.getProperties('title', 'date', 'notes');
       this.get('store').findRecord('reminder', id).then(function(reminder) {
-        reminder.set('title', reminderProps.title)
-        reminder.set('date', reminderProps.date)
-        reminder.set('notes', reminderProps.notes)
+        reminder.set('title', reminder.get('title'))
+        reminder.set('date', reminder.get('date'))
+        reminder.set('notes', reminder.get('notes'))
         reminder.save();
-      }).then(() => {
-        this.setProperties({title: '', date: '' , notes: ''})
       }).then(()=>{
         this.transitionToRoute('/reminders/' + this.model.id)
       })

--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -1,15 +1,15 @@
 <form class="edit-notes--form" {{action 'updateNote' model.id on="submit"}}>
  <label>
    Title
-   {{input class="spec-input-title" value=title}}
+   {{input class="spec-input-title" value=model.title}}
  </label>
  <label>
    Date
-   {{input class="spec-input-date" value=date}}
+   {{input class="spec-input-date" value=model.date}}
  </label>
  <label>
    Note
-   {{textarea class="spec-textarea-notes" value=notes}}
+   {{textarea class="spec-textarea-notes" value=model.notes}}
  </label>
  <button class="edit-notes--submit">Submit</button>
 </form>

--- a/app/templates/reminders/reminder/edit.hbs
+++ b/app/templates/reminders/reminder/edit.hbs
@@ -11,5 +11,6 @@
    Note
    {{textarea class="spec-textarea-notes" value=model.notes}}
  </label>
+ <button class="edit-notes--revert" {{action 'undoEdit' model.id}}>Undo</button>
  <button class="edit-notes--submit">Submit</button>
 </form>

--- a/tests/acceptance/edit-note-test.js
+++ b/tests/acceptance/edit-note-test.js
@@ -9,6 +9,7 @@ moduleForAcceptance('Acceptance | edit note')
     fillIn('.spec-input-date', 'Tomorrow');
     fillIn('.spec-textarea-notes', 'Because');
     click('.add-notes--submit');
+    
     andThen(function() {
       assert.equal(currentURL(), 'reminders/new', 'should route to reminders/new');
       assert.equal(find('.spec-reminder-item').length, 1, 'should create one note');
@@ -17,6 +18,7 @@ moduleForAcceptance('Acceptance | edit note')
 
     click('.spec-reminder-item:first');
     click('.spec-link-to-edit');
+    
     andThen(function() {
       assert.equal(currentURL(), '/reminders/1/edit', 'should route to edit page')
     });
@@ -25,6 +27,7 @@ moduleForAcceptance('Acceptance | edit note')
     fillIn('.spec-input-date', 'Tomorrow');
     fillIn('.spec-textarea-notes', 'Nah');
     click('.edit-notes--submit');
+    
     andThen(function() {
       assert.equal(currentURL(), '/reminders/1', 'clicking submit on edit page reroutes to individual reminders page');
       assert.equal(find('.spec-reminder-item').length, 1, 'should show 1 note on reminders page');
@@ -38,6 +41,7 @@ moduleForAcceptance('Acceptance | edit note')
     fillIn('.spec-input-date', 'Tomorrow');
     fillIn('.spec-textarea-notes', 'Because');
     click('.add-notes--submit');
+    
     andThen(function() {
       assert.equal(currentURL(), 'reminders/new', 'should route to reminders/new');
       assert.equal(find('.spec-reminder-item').length, 1, 'should create a note');
@@ -46,6 +50,7 @@ moduleForAcceptance('Acceptance | edit note')
 
     click('.spec-reminder-item:first');
     click('.spec-link-to-edit');
+    
     andThen(function() {
       assert.equal(currentURL(), '/reminders/1/edit', 'should route to edit page')
     });
@@ -53,10 +58,13 @@ moduleForAcceptance('Acceptance | edit note')
     fillIn('.spec-input-title', 'Remind me to get a job tomorrow');
     fillIn('.spec-input-date', 'Tomorrow');
     fillIn('.spec-textarea-notes', 'Nah');
+    
     andThen(function() {
       assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to get a job tomorrow', 'should list updated title on page before undo is clicked');
     });
-    click('.edit-notes--revert')
+    
+    click('.edit-notes--revert');
+    
     andThen(function() {
       assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to go to class', 'should revert to original title after undo is clicked.');
     })

--- a/tests/acceptance/edit-note-test.js
+++ b/tests/acceptance/edit-note-test.js
@@ -31,3 +31,33 @@ moduleForAcceptance('Acceptance | edit note')
       assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to get a job tomorrow', 'should list updated title on page');
     });
   });
+
+  test('should rollback changes when undo is clicked', function(assert) {
+    visit('reminders/new');
+    fillIn('.spec-input-title', 'Remind me to go to class');
+    fillIn('.spec-input-date', 'Tomorrow');
+    fillIn('.spec-textarea-notes', 'Because');
+    click('.add-notes--submit');
+    andThen(function() {
+      assert.equal(currentURL(), 'reminders/new', 'should route to reminders/new');
+      assert.equal(find('.spec-reminder-item').length, 1, 'should create a note');
+      assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to go to class', 'should list original note title');
+    });
+
+    click('.spec-reminder-item:first');
+    click('.spec-link-to-edit');
+    andThen(function() {
+      assert.equal(currentURL(), '/reminders/1/edit', 'should route to edit page')
+    });
+
+    fillIn('.spec-input-title', 'Remind me to get a job tomorrow');
+    fillIn('.spec-input-date', 'Tomorrow');
+    fillIn('.spec-textarea-notes', 'Nah');
+    andThen(function() {
+      assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to get a job tomorrow', 'should list updated title on page before undo is clicked');
+    });
+    click('.edit-notes--revert')
+    andThen(function() {
+      assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to go to class', 'should revert to original title after undo is clicked.');
+    })
+  });


### PR DESCRIPTION
## Purpose

User can revert an unsaved reminder to its previous state mid-edit. When actively editing a reminder, if the reminder has unsaved changes, the user will see a button to rollback unsaved changes. When clicked it will automatically rollback the attributes of the reminder to its original, clean state. closes #10

## Approach

we updated our input fields to take the value from model. this way when a user types it updates the data. then, we added an undo button and an action that calls rollbackAttributes(). simple

### Learning

OMG EMBER DOCS 🙏🏻

### Test coverage 

We wrote a test creating a new idea, then updated the value, checked that the updated value is displayed, then clicked undo to check for the original value displaying again. 



### Follow-up tasks

- [Issue #11 (visual cues changed on unsaved reminder)](https://github.com/turingschool-projects/1610-remember-6/issues/11)

### Screenshots

#### Before

![](https://cloud.githubusercontent.com/assets/19962100/22943322/61541c76-f2aa-11e6-93f8-2d65c1b3b0ad.png)


#### After

<img width="641" alt="screen shot 2017-02-14 at 4 23 22 pm" src="https://cloud.githubusercontent.com/assets/20474299/22954162/20ded636-f2d2-11e6-8780-ff1de047ed3b.png">

#### Tests

<img width="1033" alt="issue10-tests" src="https://cloud.githubusercontent.com/assets/20474299/22954139/08b10566-f2d2-11e6-9c03-f5fcdfa97134.png">