### PR TITLE
Visual cues - closes #11

### DIFF
--- a/app/controllers/reminders/reminder/edit.js
+++ b/app/controllers/reminders/reminder/edit.js
@@ -19,13 +19,5 @@ export default Ember.Controller.extend({
         reminder.rollbackAttributes();
       })
     }
-
-    // dirtyThang(id) {
-    //   this.get('store').findRecord('reminder', id, {
-    //     backgroundReload: false }).then((post)=> {
-    //     post.get('hasDirtyAttributes');
-    //
-    //   })
-    // }
   }
 });

--- a/app/controllers/reminders/reminder/edit.js
+++ b/app/controllers/reminders/reminder/edit.js
@@ -19,5 +19,13 @@ export default Ember.Controller.extend({
         reminder.rollbackAttributes();
       })
     }
+
+    // dirtyThang(id) {
+    //   this.get('store').findRecord('reminder', id, {
+    //     backgroundReload: false }).then((post)=> {
+    //     post.get('hasDirtyAttributes');
+    //
+    //   })
+    // }
   }
 });

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -3,5 +3,5 @@ import DS from 'ember-data';
 export default DS.Model.extend({
   title: DS.attr('string'),
   date: DS.attr('string'),
-  notes: DS.attr('string'),
+  notes: DS.attr('string')
 });

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -2,3 +2,7 @@
   color: magenta;
   font-weight: bold;
 }
+
+.dirty-attribute {
+  background-color: rgba(220,20,60,.2);
+}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -2,7 +2,7 @@
 
 {{#if model}}
   {{#each model as |reminder|}}
-    <li>
+    <li class={{if reminder.hasDirtyAttributes "dirty-attribute"}}>
       {{#link-to "reminders.reminder" reminder class="spec-reminder-item"}}
         {{reminder.title}}
       {{/link-to}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -1,3 +1,4 @@
+
 <h1 class="spec-reminder-title">{{model.title}}</h1>
 <div>{{model.date}}</div>
 <div>{{model.notes}}</div>

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -69,3 +69,40 @@ test('clicking delete from an individual reminder...', function(assert) {
   })
 
 });
+
+test('failing to save an edited reminder will show a visual cue', function(assert) {
+    visit('reminders/new');
+    fillIn('.spec-input-title', 'Remind me to go to class');
+    fillIn('.spec-input-date', 'Tomorrow');
+    fillIn('.spec-textarea-notes', 'Because');
+    click('.add-notes--submit');
+
+    andThen(function() {
+      assert.equal(currentURL(), 'reminders/new', 'should route to reminders/new');
+      assert.equal(find('.spec-reminder-item').length, 1, 'should create a note');
+      assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to go to class', 'should list original note title');
+    });
+
+    click('.spec-reminder-item:first');
+    click('.spec-link-to-edit');
+
+    andThen(function() {
+      assert.equal(find('.dirty-attribute').length, 0, 'reminder should not have a class of dirty-attribute');
+    })
+
+    andThen(function() {
+      assert.equal(currentURL(), '/reminders/1/edit', 'should route to edit page')
+    });
+
+    fillIn('.spec-input-title', 'Remind me to get a job tomorrow');
+    fillIn('.spec-input-date', 'Tomorrow');
+    fillIn('.spec-textarea-notes', 'Nah');
+
+    andThen(function() {
+      assert.equal(find('.spec-reminder-item').text().trim(), 'Remind me to get a job tomorrow', 'should list updated title on page');
+    });
+
+    andThen(function() {
+      assert.equal(find('.dirty-attribute').length, 1, 'reminder should have a class of dirty-attribute');
+    })
+  });

--- a/tests/acceptance/reminder-list-test.js
+++ b/tests/acceptance/reminder-list-test.js
@@ -105,4 +105,10 @@ test('failing to save an edited reminder will show a visual cue', function(asser
     andThen(function() {
       assert.equal(find('.dirty-attribute').length, 1, 'reminder should have a class of dirty-attribute');
     })
+
+    click('.edit-notes--submit');
+
+    andThen(function() {
+      assert.equal(find('.dirty-attribute').length, 0, 'reminder should not have a class of dirty-attribute after clicking save');
+    })
   });


### PR DESCRIPTION
## Purpose

close #11 

User sees visual cue that reminder has not been saved.

When a reminder has changes that have not been saved to the database/server, the user should see some kind of visual indication in the sidebar of the application on that particular note.

## Approach

We added a listener for hasDirtyAttributes that toggles on a class when the value is true.  We then add CSS that highlights titles with this attribute.

### Learning

We got sidetracked reading StackOverflow and eventually figured out that we could just add a simple listener.  

### Test coverage 

We wrote an acceptance test that verifies that the dirty-attribute class is added when a reminder has a dirty attribute.

### Follow-up tasks

None for now!

### Screenshots

#### Before

<img width="641" alt="20ded636-f2d2-11e6-8780-ff1de047ed3b" src="https://cloud.githubusercontent.com/assets/19962100/22956311/762526a2-f2de-11e6-8670-99c536036a05.png">

#### After

<img width="539" alt="screen shot 2017-02-14 at 5 45 34 pm" src="https://cloud.githubusercontent.com/assets/19962100/22956282/4bbf766a-f2de-11e6-8273-224640ea3884.png">

#### Test

<img width="1021" alt="screen shot 2017-02-14 at 5 44 16 pm" src="https://cloud.githubusercontent.com/assets/19962100/22956287/54aeadc2-f2de-11e6-96d6-ce80f4f29a36.png">


